### PR TITLE
[fix] PackBytes bug when length < MAX16BIT

### DIFF
--- a/pack.go
+++ b/pack.go
@@ -186,7 +186,7 @@ func PackBytes(writer io.Writer, value []byte) (n int, err error) {
 		n2, err := writer.Write(value)
 		return n1 + n2, err
 	} else if length < MAX16BIT {
-		n1, err := writer.Write(Bytes{RAW16, byte(length >> 16), byte(length)})
+		n1, err := writer.Write(Bytes{RAW16, byte(length >> 8), byte(length)})
 		if err != nil {
 			return n1, err
 		}

--- a/pack.go
+++ b/pack.go
@@ -167,12 +167,14 @@ func PackBool(writer io.Writer, value bool) (n int, err error) {
 
 // Packs a given value and writes it into the specified writer.
 func PackFloat32(writer io.Writer, value float32) (n int, err error) {
-	return PackUint32(writer, *(*uint32)(unsafe.Pointer(&value)))
+	_value := *(*uint32)(unsafe.Pointer(&value))
+	return writer.Write(Bytes{FLOAT, byte(_value >> 24), byte(_value >> 16), byte(_value >> 8), byte(_value)})
 }
 
 // Packs a given value and writes it into the specified writer.
 func PackFloat64(writer io.Writer, value float64) (n int, err error) {
-	return PackUint64(writer, *(*uint64)(unsafe.Pointer(&value)))
+	_value := *(*uint64)(unsafe.Pointer(&value))
+	return writer.Write(Bytes{DOUBLE, byte(_value >> 56), byte(_value >> 48), byte(_value >> 40), byte(_value >> 32), byte(_value >> 24), byte(_value >> 16), byte(_value >> 8), byte(_value)})
 }
 
 // Packs a given value and writes it into the specified writer.


### PR DESCRIPTION
```
writer.Write(Bytes{RAW16, byte(length >> 16), byte(length)})
```
```
return (uint16(data[0]) << 8) | uint16(data[1]), n, nil
```

pack mismatch with unpack when RAW16